### PR TITLE
update parser test for latest version of rrweb

### DIFF
--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -42,6 +42,7 @@ it("can parse AddEventlistener events", async () => {
       "touchmove",
       "touchstart",
       "touchend",
+      "touchcancel",
     ],
   });
 });


### PR DESCRIPTION
`rrweb` package was updated to add a new event `touchcancel`. Since the parser test pulls the latest branch of `rrweb`, it now breaks.

Here's the change that broke it: https://github.com/rrweb-io/rrweb/commit/9e226b593f470dae1957904a16dbb91f73b52f77