### PR TITLE
Fix failing sessionrecorder parser test

### DIFF
--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -42,6 +42,7 @@ it("can parse AddEventlistener events", async () => {
       "touchmove",
       "touchstart",
       "touchend",
+      "touchcancel",
     ],
   });
 });

--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -18,13 +18,13 @@ it("can parse AddEventlistener events", async () => {
   await browser.close();
   expect(report["KEYBOARD"]).toEqual({
     "http://localhost:8125/shared/event-listener.js": ["keyup"],
-    "https://cdn.jsdelivr.net/npm/rrweb@latest/dist/record/rrweb-record.min.js": [
+    "https://cdn.jsdelivr.net/npm/rrweb@1.1.3/dist/record/rrweb-record.min.js": [
       "input",
     ],
   });
   expect(report["MOUSE"]).toEqual({
     "http://localhost:8125/shared/event-listener.js": ["mousedown", "click"],
-    "https://cdn.jsdelivr.net/npm/rrweb@latest/dist/record/rrweb-record.min.js": [
+    "https://cdn.jsdelivr.net/npm/rrweb@1.1.3/dist/record/rrweb-record.min.js": [
       "mousemove",
       "mouseup",
       "mousedown",
@@ -38,7 +38,7 @@ it("can parse AddEventlistener events", async () => {
   });
   expect(report["TOUCH"]).toEqual({
     "http://localhost:8125/shared/event-listener.js": ["touchend"],
-    "https://cdn.jsdelivr.net/npm/rrweb@latest/dist/record/rrweb-record.min.js": [
+    "https://cdn.jsdelivr.net/npm/rrweb@1.1.3/dist/record/rrweb-record.min.js": [
       "touchmove",
       "touchstart",
       "touchend",

--- a/__tests__/test-pages/session_recorder.html
+++ b/__tests__/test-pages/session_recorder.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/record/rrweb-record.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/rrweb@1.1.3/dist/record/rrweb-record.min.js"></script>
     <script src="shared/event-listener.js"></script>
     <script src="shared/session-recorder-utils.js"></script>
   </head>


### PR DESCRIPTION
The session recorder test was failing because newer versions of rrweb records more touch 
events than the test was expected. This commit adds a missing event, and pins the version 
of rrweb the test is pulling in to make sure it doesn't start failing again in the future