### PR TITLE
Add some puppeteer configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Results are stored in `demo-dir` by default
 - `defaultWaitUntil`
   - default: 'networkidle2'
   - [Other options](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options)
+- `executablePath`
+  - Path to Chromium executable.
+  - default: uses bundled puppeteer chromium
+- `extraChromiumArgs`
+  - Extra flags to pass to Chromium executable
+  - default: []
 
 ## Inspection Result
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Results are stored in `demo-dir` by default
 - `defaultWaitUntil`
   - default: 'networkidle2'
   - [Other options](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options)
-- `executablePath`
+- `puppeteerExecutablePath`
   - Path to Chromium executable.
   - default: uses bundled puppeteer chromium
 - `extraChromiumArgs`

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -53,7 +53,6 @@ export const collector = async ({
   ],
   extraChromiumArgs = [],
   puppeteerExecutablePath = null,
-  defaultViewport = null,
 }) => {
   clearDir(outDir);
   const FIRST_PARTY = parse(inUrl);
@@ -123,9 +122,6 @@ export const collector = async ({
     if (puppeteerExecutablePath) {
       options["executablePath"] = puppeteerExecutablePath;
     };
-    if (defaultViewport) {
-      options["defaultViewport"] = defaultViewport;
-    };
     browser = await puppeteer.launch(options);
     browser.on("disconnected", () => {
       didBrowserDisconnect = true;
@@ -194,7 +190,7 @@ export const collector = async ({
     // Go to the url
     page_response = await page.goto(inUrl, {
       timeout: defaultTimeout,
-      waitUntil: defaultWaitUntil as PuppeteerLifeCycleEvent ,
+      waitUntil: defaultWaitUntil as PuppeteerLifeCycleEvent,
     });
     await savePageContent(pageIndex, outDir, page, saveScreenshots);
     pageIndex++;

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -51,8 +51,8 @@ export const collector = async ({
     "session_recorders",
     "third_party_trackers",
   ],
-  extraChromiumArgs = [],
   puppeteerExecutablePath = null,
+  extraChromiumArgs = [],
 }) => {
   clearDir(outDir);
   const FIRST_PARTY = parse(inUrl);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -51,6 +51,9 @@ export const collector = async ({
     "session_recorders",
     "third_party_trackers",
   ],
+  extraChromiumArgs = [],
+  puppeteerExecutablePath = null,
+  defaultViewport = null,
 }) => {
   clearDir(outDir);
   const FIRST_PARTY = parse(inUrl);
@@ -113,8 +116,15 @@ export const collector = async ({
   try {
     const options = {
       ...defaultPuppeteerBrowserOptions,
+      args: [...defaultPuppeteerBrowserOptions.args, ...extraChromiumArgs],
       headless,
       userDataDir,
+    };
+    if (puppeteerExecutablePath) {
+      options["executablePath"] = puppeteerExecutablePath;
+    };
+    if (defaultViewport) {
+      options["defaultViewport"] = defaultViewport;
     };
     browser = await puppeteer.launch(options);
     browser.on("disconnected", () => {


### PR DESCRIPTION
Includes ability to pass a chrome executable path, a default viewport, and args passed to the chromium executable