### PR TITLE
Handle errors in the collect function with a try-catch block.

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,10 +1,10 @@
-
 import { KnownDevices } from "puppeteer";
 import { CollectorOptions, collect } from "./src";
 import { join } from 'path';
 
 (async () => {
-    const URL = 'example.com';
+    // const URL = 'example.com';
+    const URL = 'www.gothamist.com';
     const EMULATE_DEVICE = 'iPhone 13 Mini';
 
     const config: CollectorOptions = {
@@ -21,7 +21,11 @@ import { join } from 'path';
 
     console.log(`Beginning scan of ${URL}`);
 
-    await collect(`http://${URL}`, config);
+    const result = await collect(`http://${URL}`, config);
 
-    console.log(`Scan complete: ${config.outDir}`);
+    if (result.status === 'success') {
+        console.log(`Scan successful: ${config.outDir}`);
+    } else {
+        console.error(`Scan failed: ${result.page_response}`);
+    }
 })();

--- a/example.ts
+++ b/example.ts
@@ -3,8 +3,7 @@ import { CollectorOptions, collect } from "./src";
 import { join } from 'path';
 
 (async () => {
-    // const URL = 'example.com';
-    const URL = 'www.gothamist.com';
+    const URL = 'example.com';
     const EMULATE_DEVICE = 'iPhone 13 Mini';
 
     const config: CollectorOptions = {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -346,16 +346,15 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             clearDir(args.outDir, false);
         }
 
-        throw new Error('Browser disconnected');
         return { status: 'success', ...output, reports };
     } catch (error) {
-        console.error(error);
-        console.log('An error occurred:');
+        // return error
         return {
             status: 'failed',
             page_response: 'Run failed, please try again'
         };
     } finally {
+        // close browser and clear tmp dir
         if (browser && !didBrowserDisconnect) {
             await browser.close();
         }

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -45,10 +45,10 @@ const DEFAULT_OPTIONS = {
         'session_recorders',
         'third_party_trackers'
     ],
-    puppeteerExecutablePath: null as string|null,
+    puppeteerExecutablePath: null as string | null,
     extraChromiumArgs: [] as string[],
     extraPuppeteerOptions: {} as Partial<PuppeteerLaunchOptions>
-}
+};
 
 export const collect = async (inUrl: string, args: CollectorOptions) => {
     args = { ...DEFAULT_OPTIONS, ...args };
@@ -104,245 +104,266 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
     let loadError = false;
     const userDataDir = args.saveBrowserProfile ? join(args.outDir, 'browser-profile') : undefined;
     let didBrowserDisconnect = false;
-
-    const options = {
-        ...defaultPuppeteerBrowserOptions,
-        args: [...defaultPuppeteerBrowserOptions.args, ...args.extraChromiumArgs],
-        headless: args.headless,
-        userDataDir
-    };
-    if (args.puppeteerExecutablePath) {
-        options['executablePath'] = args.puppeteerExecutablePath;
-    }
-    browser = await puppeteer.launch(options);
-    browser.on('disconnected', () => {
-        didBrowserDisconnect = true;
-    });
-
-    if (didBrowserDisconnect) {
-        return {
-            status: 'failed',
-            page_response: 'Chrome crashed'
+    
+    try {
+        const options = {
+            ...defaultPuppeteerBrowserOptions,
+            args: [...defaultPuppeteerBrowserOptions.args, ...args.extraChromiumArgs],
+            headless: args.headless,
+            userDataDir
         };
-    }
-    logger.info(`Started Puppeteer with pid ${browser.process().pid}`);
-    page = (await browser.pages())[0];
-    output.browser = {
-        name: 'Chromium',
-        version: await browser.version(),
-        user_agent: await browser.userAgent(),
-        platform: {
-            name: os.type(),
-            version: os.release()
+        if (args.puppeteerExecutablePath) {
+            options['executablePath'] = args.puppeteerExecutablePath;
         }
-    };
-    page.emulate(args.emulateDevice);
-
-    // record all requested hosts
-    await page.on('request', request => {
-        const l = parse(request.url());
-        // note that hosts may appear as first and third party depending on the path
-        if (FIRST_PARTY.domain === l.domain) {
-            hosts.requests.first_party.add(l.hostname);
-        } else {
-            if (request.url().indexOf('data://') < 1 && !!l.hostname) {
-                hosts.requests.third_party.add(l.hostname);
-            }
-        }
-    });
-
-    if (args.clearCache) {
-        await clearCookiesCache(page);
-    }
-
-    // Init blacklight instruments on page
-    await setupBlacklightInspector(page, logger.warn);
-    await setupKeyLoggingInspector(page, logger.warn);
-    await setupHttpCookieCapture(page, logger.warn);
-    await setupSessionRecordingInspector(page, logger.warn);
-    await setUpThirdPartyTrackersInspector(page, logger.warn, args.enableAdBlock);
-
-    if (args.captureHar) {
-        har = new PuppeteerHar(page);
-        await har.start({
-            path: args.outDir ? join(args.outDir, 'requests.har') : undefined
-        });
-    }
-    if (didBrowserDisconnect) {
-        return {
-            status: 'failed',
-            page_response: 'Chrome crashed'
-        };
-    }
-    // Go to the url
-    page_response = await page.goto(inUrl, {
-        timeout: args.defaultTimeout,
-        waitUntil: args.defaultWaitUntil as PuppeteerLifeCycleEvent
-    });
-    await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
-    pageIndex++;
-
-    let duplicatedLinks = [];
-    const outputLinks = {
-        first_party: [],
-        third_party: []
-    };
-
-    // Return if the page doesnt load
-    if (loadError) {
-        await browser.close();
-        if (typeof userDataDir !== 'undefined') {
-            clearDir(userDataDir, false);
-        }
-        if (args.outDir.includes('bl-tmp')) {
-            clearDir(args.outDir, false);
-        }
-        return { status: 'failed', page_response };
-    }
-    output.uri_redirects = page_response
-        .request()
-        .redirectChain()
-        .map(req => {
-            return req.url();
+        browser = await puppeteer.launch(options);
+        browser.on('disconnected', () => {
+            didBrowserDisconnect = true;
         });
 
-    output.uri_dest = page.url();
-    duplicatedLinks = await getLinks(page);
-    REDIRECTED_FIRST_PARTY = parse(output.uri_dest);
-    for (const link of dedupLinks(duplicatedLinks)) {
-        const l = parse(link.href);
-
-        if (REDIRECTED_FIRST_PARTY.domain === l.domain) {
-            outputLinks.first_party.push(link);
-            hosts.links.first_party.add(l.hostname);
-        } else {
-            if (l.hostname && l.hostname !== 'data') {
-                outputLinks.third_party.push(link);
-                hosts.links.third_party.add(l.hostname);
-            }
-        }
-    }
-    await fillForms(page);
-
-    let subDomainLinks = [];
-    if (getSubdomain(output.uri_dest) !== 'www') {
-        subDomainLinks = outputLinks.first_party.filter(f => {
-            return getSubdomain(f.href) === getSubdomain(output.uri_dest);
-        });
-    } else {
-        subDomainLinks = outputLinks.first_party;
-    }
-    const browse_links = sampleSize(subDomainLinks, args.numPages);
-    output.browsing_history = [output.uri_dest].concat(browse_links.map(l => l.href));
-
-    for (const link of output.browsing_history.slice(1)) {
-        logger.log('info', `browsing now to ${link}`, { type: 'Browser' });
         if (didBrowserDisconnect) {
             return {
                 status: 'failed',
                 page_response: 'Chrome crashed'
             };
         }
-        await page.goto(link, {
-            timeout: args.defaultTimeout,
-            waitUntil: 'networkidle2'
+        logger.info(`Started Puppeteer with pid ${browser.process().pid}`);
+        page = (await browser.pages())[0];
+        output.browser = {
+            name: 'Chromium',
+            version: await browser.version(),
+            user_agent: await browser.userAgent(),
+            platform: {
+                name: os.type(),
+                version: os.release()
+            }
+        };
+        page.emulate(args.emulateDevice);
+
+        // record all requested hosts
+        await page.on('request', request => {
+            const l = parse(request.url());
+            // note that hosts may appear as first and third party depending on the path
+            if (FIRST_PARTY.domain === l.domain) {
+                hosts.requests.first_party.add(l.hostname);
+            } else {
+                if (request.url().indexOf('data://') < 1 && !!l.hostname) {
+                    hosts.requests.third_party.add(l.hostname);
+                }
+            }
         });
 
+        if (args.clearCache) {
+            await clearCookiesCache(page);
+        }
+
+        // Init blacklight instruments on page
+        await setupBlacklightInspector(page, logger.warn);
+        await setupKeyLoggingInspector(page, logger.warn);
+        await setupHttpCookieCapture(page, logger.warn);
+        await setupSessionRecordingInspector(page, logger.warn);
+        await setUpThirdPartyTrackersInspector(page, logger.warn, args.enableAdBlock);
+
+        if (args.captureHar) {
+            har = new PuppeteerHar(page);
+            await har.start({
+                path: args.outDir ? join(args.outDir, 'requests.har') : undefined
+            });
+        }
+        if (didBrowserDisconnect) {
+            return {
+                status: 'failed',
+                page_response: 'Chrome crashed'
+            };
+        }
+        // Go to the url
+        page_response = await page.goto(inUrl, {
+            timeout: args.defaultTimeout,
+            waitUntil: args.defaultWaitUntil as PuppeteerLifeCycleEvent
+        });
         await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
-        await fillForms(page);
-        await page.waitForTimeout(800);
         pageIndex++;
-        duplicatedLinks = duplicatedLinks.concat(await getLinks(page));
-        await autoScroll(page);
-    }
-    await captureBrowserCookies(page, args.outDir);
-    if (args.captureHar) {
-        await har.stop();
-    }
 
-    await browser.close();
-    if (typeof userDataDir !== 'undefined') {
-        clearDir(userDataDir, false);
-    }
+        let duplicatedLinks = [];
+        const outputLinks = {
+            first_party: [],
+            third_party: []
+        };
 
-    const links = dedupLinks(duplicatedLinks);
-    output.end_time = new Date();
-    for (const link of links) {
-        const l = parse(link.href);
-
-        if (REDIRECTED_FIRST_PARTY.domain === l.domain) {
-            outputLinks.first_party.push(link);
-            hosts.links.first_party.add(l.hostname);
-        } else {
-            if (l.hostname && l.hostname !== 'data') {
-                outputLinks.third_party.push(link);
-                hosts.links.third_party.add(l.hostname);
+        // Return if the page doesnt load
+        if (loadError) {
+            await browser.close();
+            if (typeof userDataDir !== 'undefined') {
+                clearDir(userDataDir, false);
             }
+            if (args.outDir.includes('bl-tmp')) {
+                clearDir(args.outDir, false);
+            }
+            return { status: 'failed', page_response };
         }
-    }
-    // generate report
-    const fpRequests = Array.from(hosts.requests.first_party);
-    const tpRequests = Array.from(hosts.requests.third_party);
-    const incorrectTpAssignment = tpRequests.filter((f: string) => getDomain(f) === REDIRECTED_FIRST_PARTY.domain);
-    output.hosts = {
-        requests: {
-            first_party: fpRequests.concat(incorrectTpAssignment),
-            third_party: tpRequests.filter(t => !incorrectTpAssignment.includes(t))
-        }
-    };
+        output.uri_redirects = page_response
+            .request()
+            .redirectChain()
+            .map(req => {
+                return req.url();
+            });
 
-    if (args.captureLinks) {
-        output.links = outputLinks;
-        output.social = getSocialLinks(links);
-    }
+        output.uri_dest = page.url();
+        duplicatedLinks = await getLinks(page);
+        REDIRECTED_FIRST_PARTY = parse(output.uri_dest);
+        for (const link of dedupLinks(duplicatedLinks)) {
+            const l = parse(link.href);
 
-    const event_data_all = await new Promise(done => {
-        logger.query(
-            {
-                start: 0,
-                order: 'desc',
-                limit: Infinity,
-                fields: ['message']
-            },
-            (err, results) => {
-                if (err) {
-                    console.log(`Couldnt load event data ${JSON.stringify(err)}`);
-                    return done([]);
+            if (REDIRECTED_FIRST_PARTY.domain === l.domain) {
+                outputLinks.first_party.push(link);
+                hosts.links.first_party.add(l.hostname);
+            } else {
+                if (l.hostname && l.hostname !== 'data') {
+                    outputLinks.third_party.push(link);
+                    hosts.links.third_party.add(l.hostname);
                 }
-
-                return done(results.file);
             }
-        );
-    });
+        }
+        await fillForms(page);
 
-    if (!Array.isArray(event_data_all)) {
+        let subDomainLinks = [];
+        if (getSubdomain(output.uri_dest) !== 'www') {
+            subDomainLinks = outputLinks.first_party.filter(f => {
+                return getSubdomain(f.href) === getSubdomain(output.uri_dest);
+            });
+        } else {
+            subDomainLinks = outputLinks.first_party;
+        }
+        const browse_links = sampleSize(subDomainLinks, args.numPages);
+        output.browsing_history = [output.uri_dest].concat(browse_links.map(l => l.href));
+
+        for (const link of output.browsing_history.slice(1)) {
+            logger.log('info', `browsing now to ${link}`, { type: 'Browser' });
+            if (didBrowserDisconnect) {
+                return {
+                    status: 'failed',
+                    page_response: 'Chrome crashed'
+                };
+            }
+            await page.goto(link, {
+                timeout: args.defaultTimeout,
+                waitUntil: 'networkidle2'
+            });
+
+            await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
+            await fillForms(page);
+            await page.waitForTimeout(800);
+            pageIndex++;
+            duplicatedLinks = duplicatedLinks.concat(await getLinks(page));
+            await autoScroll(page);
+        }
+        await captureBrowserCookies(page, args.outDir);
+        if (args.captureHar) {
+            await har.stop();
+        }
+
+        await browser.close();
+        if (typeof userDataDir !== 'undefined') {
+            clearDir(userDataDir, false);
+        }
+
+        const links = dedupLinks(duplicatedLinks);
+        output.end_time = new Date();
+        for (const link of links) {
+            const l = parse(link.href);
+
+            if (REDIRECTED_FIRST_PARTY.domain === l.domain) {
+                outputLinks.first_party.push(link);
+                hosts.links.first_party.add(l.hostname);
+            } else {
+                if (l.hostname && l.hostname !== 'data') {
+                    outputLinks.third_party.push(link);
+                    hosts.links.third_party.add(l.hostname);
+                }
+            }
+        }
+        // generate report
+        const fpRequests = Array.from(hosts.requests.first_party);
+        const tpRequests = Array.from(hosts.requests.third_party);
+        const incorrectTpAssignment = tpRequests.filter((f: string) => getDomain(f) === REDIRECTED_FIRST_PARTY.domain);
+        output.hosts = {
+            requests: {
+                first_party: fpRequests.concat(incorrectTpAssignment),
+                third_party: tpRequests.filter(t => !incorrectTpAssignment.includes(t))
+            }
+        };
+
+        if (args.captureLinks) {
+            output.links = outputLinks;
+            output.social = getSocialLinks(links);
+        }
+
+        const event_data_all = await new Promise(done => {
+            logger.query(
+                {
+                    start: 0,
+                    order: 'desc',
+                    limit: Infinity,
+                    fields: ['message']
+                },
+                (err, results) => {
+                    if (err) {
+                        console.log(`Couldnt load event data ${JSON.stringify(err)}`);
+                        return done([]);
+                    }
+
+                    return done(results.file);
+                }
+            );
+        });
+
+        if (!Array.isArray(event_data_all)) {
+            return {
+                status: 'failed',
+                page_response: 'Couldnt load event data'
+            };
+        }
+        if (event_data_all.length < 1) {
+            return {
+                status: 'failed',
+                page_response: 'Couldnt load event data'
+            };
+        }
+
+        // filter only events with type set
+        const event_data = event_data_all.filter(event => {
+            return !!event.message.type;
+        });
+        // We only consider something to be a third party tracker if:
+        // The domain is different to that of the final url (after any redirection) of the page the user requested to load.
+        const reports = args.blTests.reduce((acc, cur) => {
+            acc[cur] = generateReport(cur, event_data, args.outDir, REDIRECTED_FIRST_PARTY.domain);
+            return acc;
+        }, {});
+
+        const json_dump = JSON.stringify({ ...output, reports }, null, 2);
+        writeFileSync(join(args.outDir, 'inspection.json'), json_dump);
+        if (args.outDir.includes('bl-tmp')) {
+            clearDir(args.outDir, false);
+        }
+
+        throw new Error('Browser disconnected');
+        return { status: 'success', ...output, reports };
+    } catch (error) {
+        console.error(error);
+        console.log('An error occurred:');
         return {
             status: 'failed',
-            page_response: 'Couldnt load event data'
+            page_response: 'Run failed, please try again'
         };
+    } finally {
+        if (browser && !didBrowserDisconnect) {
+            await browser.close();
+        }
+        if (typeof userDataDir !== 'undefined') {
+            clearDir(userDataDir, false);
+        }
+        if (args.outDir.includes('bl-tmp')) {
+            clearDir(args.outDir, false);
+        }
     }
-    if (event_data_all.length < 1) {
-        return {
-            status: 'failed',
-            page_response: 'Couldnt load event data'
-        };
-    }
-
-    // filter only events with type set
-    const event_data = event_data_all.filter(event => {
-        return !!event.message.type;
-    });
-    // We only consider something to be a third party tracker if:
-    // The domain is different to that of the final url (after any redirection) of the page the user requested to load.
-    const reports = args.blTests.reduce((acc, cur) => {
-        acc[cur] = generateReport(cur, event_data, args.outDir, REDIRECTED_FIRST_PARTY.domain);
-        return acc;
-    }, {});
-
-    const json_dump = JSON.stringify({ ...output, reports }, null, 2);
-    writeFileSync(join(args.outDir, 'inspection.json'), json_dump);
-    if (args.outDir.includes('bl-tmp')) {
-        clearDir(args.outDir, false);
-    }
-    return { status: 'success', ...output, reports };
 };


### PR DESCRIPTION
This PR potentially fix the [issue](https://github.com/the-markup/blacklight-collector/issues/53) of tmp file not properly cleared after a failed scan, leading to: `ENOSPC: no space left on device, mkdir '/tmp/tmp-8-bsc9NMF2bYaq'`

Here's a brief summary of the changes:

- Added a `try-catch` block to the async function to ensure all exceptions are caught and handled appropriately.
- Upon an error, the browser is closed to free up resources. User data directory and output directory are cleared in case of an error to ensure no data remains.
- In the case of an error, the function now returns an object with status 'failed' and a message indicating that the run failed. Finally, it will make sure to clean tmp directories to handle the next scan.
- `example.ts` also got updated with error logging.