### PR TITLE
Fix URL query parsing

### DIFF
--- a/src/third-party-trackers.ts
+++ b/src/third-party-trackers.ts
@@ -41,11 +41,14 @@ export const setUpThirdPartyTrackersInspector = async (
 
             isBlocked = true;
 
-            const query = new URL(request.url()).searchParams;
-            for (const param in query) {
+            const params = new URL(request.url()).searchParams;
+            const query = {};
+            for (const [key, value] of params.entries()) {
                 try {
-                    query[param] = JSON.parse(query[param]);
-                } catch {}
+                    query[key] = JSON.parse(value);
+                } catch {
+                    query[key] = value;
+                }
             }
 
             eventDataHandler({


### PR DESCRIPTION
Fixes an issue with parsing URL query params.

Test case: running an inspection on `joebiden.com` (which should have 1 Meta Pixel event).

`inspection.json` before:
```
"fb_pixel_events": []
```

`inspection.json` after:
```
"fb_pixel_events": [
      {
        "advancedMatchingParams": [],
        "dataParams": [],
        "eventDescription": "This is the default pixel tracking page visits. For example - A person lands on your website pages.",
        "eventName": "PageView",
        "isStandardEvent": true,
        "pageUrl": "https://joebiden.com/",
        "raw": "https://www.facebook.com/tr/?id=1663341264181988&ev=PageView&dl=https%3A%2F%2Fjoebiden.com%2F&rl=&if=false&ts=1690989233346&sw=375&sh=812&v=2.9.120&r=stable&ec=0&o=30&fbp=fb.1.1690989233321.1427339459&it=1690989233055&coo=false&exp=a3&rqm=GET"
      }
    ],
```