### PR TITLE
Script hash

### DIFF
--- a/.commit-hash.cjs
+++ b/.commit-hash.cjs
@@ -1,0 +1,1 @@
+module.exports='dev';

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,3 @@ build
 !__tests__/test-data/veteransunitedsession/*
 !__tests__/test-data/veteransunited-1.0.3/*
 !__tests__/test-pages/*
-
-# versioning
-.script-hash.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ build
 !__tests__/test-data/veteransunitedsession/*
 !__tests__/test-data/veteransunited-1.0.3/*
 !__tests__/test-pages/*
+
+# versioning
+.script-hash.cjs

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "version-beta": "git stash && standard-version --prerelease beta",
     "version-major": "git stash && standard-version --release-as major",
     "version-minor": "git stash && standard-version --release-as minor",
-    "version-patch": "git stash && standard-version --release-as patch"
+    "version-patch": "git stash && standard-version --release-as patch",
+    "commit-hash": "echo \"module.exports='$(git show --format=%H | head -n 1)';\" > .commit-hash.cjs"
   },
   "repository": {
     "type": "git",

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -76,7 +76,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             host: os.hostname(),
             version: {
                 npm: require('../package.json').version,
-                commit: null
+                commit: require('../.commit-hash.cjs')
             },
             node_version: process.version
         },
@@ -104,7 +104,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
     let loadError = false;
     const userDataDir = args.saveBrowserProfile ? join(args.outDir, 'browser-profile') : undefined;
     let didBrowserDisconnect = false;
-    
+
     try {
         const options = {
             ...defaultPuppeteerBrowserOptions,


### PR DESCRIPTION
- Adds a file `.commit-hash.cjs` that stores the current Git repo commit hash (`dev` by default)
- Adds a new command `npm run commit-hash` to update the `.commit-hash.cjs`
- Includes the current commit hash from `.commit-hash.cjs` with inspection results