### PR TITLE
Update TS-value to get example to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^2.8.8",
     "standard-version": "^9.0.0",
     "ts-jest": "^28.0.2",
-    "ts-node": "^8.5.4",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   },
   "config": {


### PR DESCRIPTION
Currently, jest is running a higher version of ts-node than is being required in the package. 

@themarkup/blacklight-collector@3.0.3 /Users/yashparikh/node_modules/@themarkup/blacklight-collector
├─┬ jest@28.1.3
│ ├─┬ @jest/core@28.1.3
│ │ └─┬ jest-config@28.1.3
│ │   └── ts-node@10.9.2
│ └─┬ jest-cli@28.1.3
│   └─┬ jest-config@28.1.3
│     └── ts-node@10.9.2
└── ts-node@8.10.2

This led to the following issue:
                ^
TypeError: Unable to require file: src/index.ts
This is usually the result of a faulty configuration or import. Make sure there is a `.js`, `.json` or other executable extension with loader attached before `ts-node` available.
    at getOutput (/Users/yashparikh/node_modules/@themarkup/blacklight-collector/node_modules/ts-node/src/index.ts:586:17)
    at Object.compile (/Users/yashparikh/node_modules/@themarkup/blacklight-collector/node_modules/ts-node/src/index.ts:775:32)
    at Module.m._compile (/Users/yashparikh/node_modules/@themarkup/blacklight-collector/node_modules/ts-node/src/index.ts:858:43)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/yashparikh/node_modules/@themarkup/blacklight-collector/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/yashparikh/node_modules/@themarkup/blacklight-collector/example.ts:2:1)


Updating the ts-node version has resolved this issue for me!