### PR TITLE
removing unused build dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "https://github.com/the-markup/blacklight-collector#licensing",
       "dependencies": {
         "@cliqz/adblocker-puppeteer": "^1.23.8",
-        "build": "^0.1.4",
         "lodash.flatten": "^4.4.0",
         "lodash.samplesize": "^4.2.0",
         "npm": "^9.8.1",
@@ -3270,34 +3269,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "node_modules/build": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha512-KwbDJ/zrsU8KZRRMfoURG14cKIAStUlS8D5jBDvtrZbwO5FEkYqc3oB8HIhRiyD64A48w1lc+sOmQ+mmBw5U/Q==",
-      "dependencies": {
-        "cssmin": "0.3.x",
-        "jsmin": "1.x",
-        "jxLoader": "*",
-        "moo-server": "*",
-        "promised-io": "*",
-        "timespan": "2.x",
-        "uglify-js": "1.x",
-        "walker": "1.x",
-        "winston": "*",
-        "wrench": "1.3.x"
-      },
-      "engines": {
-        "node": ">v0.4.12"
-      }
-    },
-    "node_modules/build/node_modules/uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4150,14 +4121,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cssmin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha512-bynxGIAJ8ybrnFobjsQotIjA8HFDDgPwbeUWNXXXfR+B4f9kkxdcUyagJoQCSUOfMV+ZZ6bMn8bvbozlCzUGwQ==",
-      "bin": {
-        "cssmin": "bin/cssmin"
       }
     },
     "node_modules/cwd": {
@@ -9266,17 +9229,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/jsmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==",
-      "bin": {
-        "jsmin": "bin/jsmin"
-      },
-      "engines": {
-        "node": ">=0.1.93"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9375,28 +9327,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/jxLoader": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha512-ClEvAj3K68y8uKhub3RgTmcRPo5DfIWvtxqrKQdDPyZ1UVHIIKvVvjrAsJFSVL5wjv0rt5iH9SMCZ0XRKNzeUA==",
-      "dependencies": {
-        "js-yaml": "0.3.x",
-        "moo-server": "1.3.x",
-        "promised-io": "*",
-        "walker": "1.x"
-      },
-      "engines": {
-        "node": ">v0.4.10"
-      }
-    },
-    "node_modules/jxLoader/node_modules/js-yaml": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-      "integrity": "sha512-/7PsVDNP2tVe2Z1cF9kTEkjamIwz4aooDpRKmN1+g/9eePCgcxsv4QDvEbxO0EH+gdDD7MLyDoR6BASo3hH51g==",
-      "engines": {
-        "node": "> 0.4.11"
       }
     },
     "node_modules/kind-of": {
@@ -9687,6 +9617,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -10033,14 +9964,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moo-server": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-      "integrity": "sha512-9A8/eor2DXwpv1+a4pZAAydqLFVrWoKoO1fzdzqLUhYVXAO1Kgd1FR2gFZi7YdHzF0s4W8cDNwCfKJQrvLqxDw==",
-      "engines": {
-        "node": ">v0.4.10"
       }
     },
     "node_modules/ms": {
@@ -13637,11 +13560,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promised-io": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.6.tgz",
-      "integrity": "sha512-bNwZusuNIW4m0SPR8jooSyndD35ggirHlxVl/UhIaZD/F0OBv9ebfc6tNmbpZts3QXHggkjIBH8lvtnzhtcz0A=="
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -15115,14 +15033,6 @@
         "readable-stream": "3"
       }
     },
-    "node_modules/timespan": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-      "integrity": "sha512-0Jq9+58T2wbOyLth0EU+AUb6JMGCLaTWIykJFa7hyAybjVH9gpVMTfUAwo5fWAvtFt2Tjh/Elg8JtgNpnMnM8g==",
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/tldts": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.0.2.tgz",
@@ -15177,7 +15087,8 @@
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -15715,6 +15626,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -15875,15 +15787,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/wrench": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-      "integrity": "sha512-srTJQmLTP5YtW+F5zDuqjMEZqLLr/eJOZfDI5ibfPfRMeDh3oBUefAscuH0q5wBKE339ptH/S/0D18ZkfOfmKQ==",
-      "deprecated": "wrench.js is deprecated! You should check out fs-extra (https://github.com/jprichardson/node-fs-extra) for any operations you were using wrench for. Thanks for all the usage over the years.",
-      "engines": {
-        "node": ">=0.1.97"
-      }
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://github.com/the-markup/blacklight-collector#readme",
   "dependencies": {
     "@cliqz/adblocker-puppeteer": "^1.23.8",
-    "build": "^0.1.4",
     "lodash.flatten": "^4.4.0",
     "lodash.samplesize": "^4.2.0",
     "npm": "^9.8.1",


### PR DESCRIPTION
Removing the very deprecated `build` dependency, which doesn't seem to be used in the project.

To test:

- build the collector locally, verify that the build works
- attach local collector to your local `blacklight-lambda`, and test that sending `curl` requests from the terminal returns as expected
- attach that local lambda to local version of the graphic (instructions on how to do this are in the READMEs of both repos) and ensure that everything works and looks correct