### PR TITLE
Add headers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Results are stored in `demo-dir` by default
   - default: 'Blacklight Inspection'
 - `saveScreenshots`
   - default: true
+- `addRequestHeaders`
+  - default: `{}` (expects `{ "[header]": "[value]", ... }`)
 - `defaultTimeout`
   - default: 30000
   - amount of time the page will wait to load

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Results are stored in `demo-dir` by default
   - default: 'Blacklight Inspection'
 - `saveScreenshots`
   - default: true
-- `addRequestHeaders`
-  - default: `{}` (expects `{ "[header]": "[value]", ... }`)
+- `headers`
+  - default: `{}` (expects `{ "[HTTP header]": "[value]", ... }`)
 - `defaultTimeout`
   - default: 30000
   - amount of time the page will wait to load

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themarkup/blacklight-collector",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themarkup/blacklight-collector",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "https://github.com/the-markup/blacklight-collector#licensing",
       "dependencies": {
         "@cliqz/adblocker-puppeteer": "^1.23.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themarkup/blacklight-collector",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "A real-time website privacy inspector.",
   "main": "build/index.js",
   "scripts": {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -155,8 +155,6 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
                     hosts.requests.third_party.add(l.hostname);
                 }
             }
-            const headers = request.headers();
-            console.log(headers);
         });
 
         if (args.clearCache) {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -35,6 +35,7 @@ const DEFAULT_OPTIONS = {
     defaultWaitUntil: 'networkidle2' as PuppeteerLifeCycleEvent,
     saveBrowserProfile: false,
     saveScreenshots: true,
+    addRequestHeaders: {},
     blTests: [
         'behaviour_event_listeners',
         'canvas_fingerprinters',
@@ -139,6 +140,10 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         };
         page.emulate(args.emulateDevice);
 
+        if (Object.keys(args.addRequestHeaders).length > 0) {
+            page.setExtraHTTPHeaders(args.addRequestHeaders);
+        }
+
         // record all requested hosts
         await page.on('request', request => {
             const l = parse(request.url());
@@ -150,6 +155,8 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
                     hosts.requests.third_party.add(l.hostname);
                 }
             }
+            const headers = request.headers();
+            console.log(headers);
         });
 
         if (args.clearCache) {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -35,7 +35,7 @@ const DEFAULT_OPTIONS = {
     defaultWaitUntil: 'networkidle2' as PuppeteerLifeCycleEvent,
     saveBrowserProfile: false,
     saveScreenshots: true,
-    addRequestHeaders: {},
+    headers: {},
     blTests: [
         'behaviour_event_listeners',
         'canvas_fingerprinters',
@@ -140,8 +140,8 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         };
         page.emulate(args.emulateDevice);
 
-        if (Object.keys(args.addRequestHeaders).length > 0) {
-            page.setExtraHTTPHeaders(args.addRequestHeaders);
+        if (Object.keys(args.headers).length > 0) {
+            page.setExtraHTTPHeaders(args.headers);
         }
 
         // record all requested hosts


### PR DESCRIPTION
Adds a new `headers` option and bumps the version to 3.1.0.

```
const result = await collect(`https://themarkup.org`, {
    numPages: 1,
    headless: false,
    headers: {
        "Sec-GPC": "1"
    }
});
```