### PR TITLE
Close Browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
         "lodash.samplesize": "^4.2.0",
         "npm": "^10.5.2",
         "puppeteer": "^22.13.1",
-        "puppeteer-har": "^1.1.1",
-        "run": "^1.4.0",
-        "stacktrace-js": "^2.0.1",
-        "tldts": "^6.0.2",
-        "tmp": "^0.1.0",
+        "puppeteer-har": "^1.1.2",
+        "run": "^1.5.0",
+        "stacktrace-js": "^2.0.2",
+        "tldts": "^6.1.34",
+        "tmp": "^0.2.3",
         "tough-cookie": "^4.1.4",
-        "winston": "^3.2.1"
+        "winston": "^3.13.1"
       },
       "devDependencies": {
         "@types/chrome": "^0.0.268",
@@ -5747,7 +5747,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -6109,6 +6110,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6573,6 +6575,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12905,6 +12908,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14535,20 +14539,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.32",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.32.tgz",
-      "integrity": "sha512-M5zZuEGvVz6YAwt3w93zhtBXbW0K4KF4ejzuBULyVp40u/FTQVpLj01zwYTlUkgYqYprTqxCfQFfZSWgz5fJnw==",
+      "version": "6.1.34",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.34.tgz",
+      "integrity": "sha512-ErJIL8DMj1CLBER2aFrjI3IfhtuJD/jEYJA/iQg9wW8dIEPXNl4zcI/SGUihMsM/lP/Jyd8c2ETv6Cwtnk0/RQ==",
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.32"
+        "tldts-core": "^6.1.34"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.32",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.32.tgz",
-      "integrity": "sha512-XfnnY74YWMBfE6BNpi33GCpjzw0lJUUmUW+bKukARTD4IChV9plBnu4wRvl/rN8mnoXA+xAEpVN8XfmtKvQWlA=="
+      "version": "6.1.34",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.34.tgz",
+      "integrity": "sha512-Hb/jAm14h5x5+gO5Cv5wabKO0pbLlRoryvCC9v0t8OleZ4vXEKego7Mq1id/X1C8Vw1E0QCCQzGdWHkKFtxFrQ==",
+      "license": "MIT"
     },
     "node_modules/tldts-experimental": {
       "version": "6.1.32",
@@ -14559,26 +14565,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "lodash.samplesize": "^4.2.0",
     "npm": "^10.5.2",
     "puppeteer": "^22.13.1",
-    "puppeteer-har": "^1.1.1",
-    "run": "^1.4.0",
-    "stacktrace-js": "^2.0.1",
-    "tldts": "^6.0.2",
-    "tmp": "^0.1.0",
+    "puppeteer-har": "^1.1.2",
+    "run": "^1.5.0",
+    "stacktrace-js": "^2.0.2",
+    "tldts": "^6.1.34",
+    "tmp": "^0.2.3",
     "tough-cookie": "^4.1.4",
-    "winston": "^3.2.1"
+    "winston": "^3.13.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.268",

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -16,7 +16,7 @@ import { dedupLinks, getLinks, getSocialLinks } from './pptr-utils/get-links';
 import { autoScroll, fillForms } from './pptr-utils/interaction-utils';
 import { setupSessionRecordingInspector } from './session-recording';
 import { setUpThirdPartyTrackersInspector } from './third-party-trackers';
-import { clearDir } from './utils';
+import { clearDir, closeBrowser } from './utils';
 
 export type CollectorOptions = Partial<typeof DEFAULT_OPTIONS>;
 
@@ -222,7 +222,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         // Return if the page doesnt load
         if (loadError) {
             console.log("browser close 1");
-            await browser.close();
+            await closeBrowser(browser);
             if (typeof userDataDir !== 'undefined') {
                 clearDir(userDataDir, false);
             }
@@ -306,7 +306,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
 
         console.log('closing browser 1');
         console.log(browser);
-        await browser.close();
+        await closeBrowser(browser);
         console.log('... done closing browser 1');
         if (typeof userDataDir !== 'undefined') {
             clearDir(userDataDir, false);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -221,7 +221,6 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
 
         // Return if the page doesnt load
         if (loadError) {
-            console.log("browser close 1");
             await closeBrowser(browser);
             if (typeof userDataDir !== 'undefined') {
                 clearDir(userDataDir, false);
@@ -304,10 +303,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             // console.log('... done saving har');
         }
 
-        console.log('closing browser 1');
-        console.log(browser);
         await closeBrowser(browser);
-        console.log('... done closing browser 1');
         if (typeof userDataDir !== 'undefined') {
             clearDir(userDataDir, false);
         }
@@ -404,9 +400,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
     finally {
         // close browser and clear tmp dir
         if (browser && !didBrowserDisconnect) {
-            console.log("closing browser 2");
-            await browser.close();
-            console.log("done closing browser 2");
+            await closeBrowser(browser);
         }
         // if (typeof userDataDir !== 'undefined') {
         //     clearDir(userDataDir, false);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -306,7 +306,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
 
         console.log('closing browser');
         await browser.close();
-        // console.log('... done closing browser');
+        console.log('... done closing browser');
         if (typeof userDataDir !== 'undefined') {
             clearDir(userDataDir, false);
         }
@@ -405,6 +405,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         if (browser && !didBrowserDisconnect) {
             console.log("closing browser");
             await browser.close();
+            console.log("done closing browser 2");
         }
         // if (typeof userDataDir !== 'undefined') {
         //     clearDir(userDataDir, false);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -304,9 +304,10 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             // console.log('... done saving har');
         }
 
-        console.log('closing browser');
+        console.log('closing browser 1');
+        console.log(browser);
         await browser.close();
-        console.log('... done closing browser');
+        console.log('... done closing browser 1');
         if (typeof userDataDir !== 'undefined') {
             clearDir(userDataDir, false);
         }
@@ -403,7 +404,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
     finally {
         // close browser and clear tmp dir
         if (browser && !didBrowserDisconnect) {
-            console.log("closing browser");
+            console.log("closing browser 2");
             await browser.close();
             console.log("done closing browser 2");
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,10 +30,14 @@ const deleteFolderRecursive = path => {
 export const closeBrowser = async (browser) => {
     console.log("closing browser");
     const pages = await browser.pages();
+    console.log(`closing ${pages.count} pages`);
     for (let i = 0; i < pages.length; i++) {
       await pages[i].close();
+      console.log('closed page');
     }
+    console.log("before closing browser");
     await browser.close();
+    console.log("after closing browser");
 };
 
 export const clearDir = (outDir, mkNewDir = true) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,10 @@ export const closeBrowser = async (browser) => {
       await pages[i].close();
       console.log('closed page');
     }
-
+    const childProcess = browser.process()
+    if (childProcess) {
+        childProcess.kill(9)
+    }
     console.log("before closing browser");
     await browser.close();
     console.log("after closing browser");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,17 @@ const deleteFolderRecursive = path => {
     }
 };
 
+export const closeBrowser = async (browser) => {
+    const childProcess = browser.process();
+    if (childProcess) {
+        console.log("killing child process, ", childProcess);
+        childProcess.kill(9);
+    }
+    console.log("closing browser");
+    await browser.close();
+    console.log("done closing browser");
+};
+
 export const clearDir = (outDir, mkNewDir = true) => {
     if (fs.existsSync(outDir)) {
         deleteFolderRecursive(outDir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,13 +28,15 @@ const deleteFolderRecursive = path => {
 };
 
 export const closeBrowser = async (browser) => {
-    console.log("closing browser");
+    console.log("closing browser 1");
+    console.log(browser);
     const pages = await browser.pages();
     console.log(`closing ${pages.length} pages`);
     for (let i = 0; i < pages.length; i++) {
       await pages[i].close();
       console.log('closed page');
     }
+    console.log("terminating child process");
     const childProcess = browser.process()
     if (childProcess) {
         childProcess.kill(9)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,9 @@ const deleteFolderRecursive = path => {
     }
 };
 
+// This is an annoying hack to get around an issue in Puppeteer
+// where the browser.close method hangs indefinitely
+// See https://github.com/Sparticuz/chromium/issues/85#issuecomment-1527692751
 export const closeBrowser = async (browser) => {
     console.log("closing browser");
     const pages = await browser.pages();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,14 +28,12 @@ const deleteFolderRecursive = path => {
 };
 
 export const closeBrowser = async (browser) => {
-    const childProcess = browser.process();
-    if (childProcess) {
-        console.log("killing child process, ", childProcess);
-        childProcess.kill(9);
-    }
     console.log("closing browser");
+    const pages = await browser.pages();
+    for (let i = 0; i < pages.length; i++) {
+      await pages[i].close();
+    }
     await browser.close();
-    console.log("done closing browser");
 };
 
 export const clearDir = (outDir, mkNewDir = true) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,22 +28,16 @@ const deleteFolderRecursive = path => {
 };
 
 export const closeBrowser = async (browser) => {
-    console.log("closing browser 1");
-    console.log(browser);
+    console.log("closing browser");
     const pages = await browser.pages();
-    console.log(`closing ${pages.length} pages`);
     for (let i = 0; i < pages.length; i++) {
       await pages[i].close();
-      console.log('closed page');
     }
-    console.log("terminating child process");
     const childProcess = browser.process()
     if (childProcess) {
         childProcess.kill(9)
     }
-    console.log("before closing browser");
     await browser.close();
-    console.log("after closing browser");
 };
 
 export const clearDir = (outDir, mkNewDir = true) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,11 +30,12 @@ const deleteFolderRecursive = path => {
 export const closeBrowser = async (browser) => {
     console.log("closing browser");
     const pages = await browser.pages();
-    console.log(`closing ${pages.count} pages`);
+    console.log(`closing ${pages.length} pages`);
     for (let i = 0; i < pages.length; i++) {
       await pages[i].close();
       console.log('closed page');
     }
+
     console.log("before closing browser");
     await browser.close();
     console.log("after closing browser");


### PR DESCRIPTION
#### What does this PR do?
- updates packages
- Adds hacky method to force-close the browser. `browser.close()` was hanging indefinitely, leading to the lambda timing out. This 'solution' is in several Github Issue threads about the bug, such as [this one](https://github.com/Sparticuz/chromium/issues/85#issuecomment-1527692751)

Pairs with [Blacklight Lambda PR 73](https://github.com/the-markup/blacklight-lambda/pull/73)

#### Why are we doing this? How does it help us?
The recent updates to puppeteer and the collector types broke Blacklight on staging.

#### How/where should this be tested?
In staging, and locally, by running the collector and lambda and ensuring BL works

#### What are potential areas for future improvement? Are there any dependencies (especially on 3rd party code)?
Keep an eye on Puppeteer and Chromium releases, hopefully a future one will eliminate this bug

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x ] Tested manually locally *( )*
* [x ] Tested manually on staging *( )*


