### PR TITLE
fix(readme): Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Results are stored in `demo-dir` by default
   - amount of time the page will wait to load
 - `defaultWaitUntil`
   - default: 'networkidle2'
-  - [Other options](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options)
+  - [Other options](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent/)
 - `puppeteerExecutablePath`
   - Path to Chromium executable.
   - default: uses bundled puppeteer chromium


### PR DESCRIPTION
#### What does this PR do?
Fix the broken link in readme. The `Other options` for the `defaultWaitUntil` config was pointing to https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options, which is now 404. Replacing it with a link to Puppeteer LifeCycleEvent Docs page https://pptr.dev/api/puppeteer.puppeteerlifecycleevent/


#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Tested manually
* [ ] Checked for performance implications? *( )*
* [ ] Checked for security vulnerabilities? *( )*
* [x] Added/updated documentation? *( )*
* [ ] Added/updated tests
