### PR TITLE
fix(puppeteer): Default allow 3rd party cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Results are stored in `demo-dir` by default
   - default: uses bundled puppeteer chromium
 - `extraChromiumArgs`
   - Extra flags to pass to Chromium executable
-  - default: []
+  - default: ['--disable-features=TrackingProtection3pcd']
 
 ## Inspection Result
 

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -47,7 +47,7 @@ const DEFAULT_OPTIONS = {
         'third_party_trackers'
     ],
     puppeteerExecutablePath: null as string | null,
-    extraChromiumArgs: [] as string[],
+    extraChromiumArgs: ['--disable-features=TrackingProtection3pcd'] as string[],
     extraPuppeteerOptions: {} as Partial<PuppeteerLaunchOptions>
 };
 


### PR DESCRIPTION
#### What does this PR do?
With the latest update from Google/Chrome on deprecating 3rd Party cookies and trackers, chromium now by default enable the `block 3rd party cookie` feature, which result in inaccurate result from blacklight-collector as the 3rd party cookies are blocked by chromium and not visible to the outcome of the script.

#### Why are we doing this? How does it help us?
Adding the `'--disable-features=TrackingProtection3pcd'` as default arg to chromium so that 3rd-party cookie blocking is disabled by default. This will prevent blacklight-collector from giving people the illusion of certain site does not have 3rd party cookies because they did not show up in the outcome.

#### How/where should this be tested?

#### What are potential areas for future improvement? Are there any dependencies (especially on 3rd party code)?
N/A

#### What are the relevant tickets, tasks, or documents?
https://developers.google.com/privacy-sandbox/cookies/prepare/test-for-breakage#:~:text=%2D%2Ddisable%2Dfeatures%3DTrackingProtection3pcd

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x] Tested manually
* [ ] Checked for performance implications? *(N/A)*
* [ ] Checked for security vulnerabilities? *(N/A)*
* [x] Added/updated documentation? *( )*
* [ ] Added/updated tests

#### TODOs / next steps:

* [ ] *TODOs here*