### PR TITLE
Add location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ Results are stored in `demo-dir` by default
   - default: 'networkidle2'
   - [Other options](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent/)
 - `puppeteerExecutablePath`
-  - Path to Chromium executable.
   - default: uses bundled puppeteer chromium
+  - Path to Chromium executable.
 - `extraChromiumArgs`
-  - Extra flags to pass to Chromium executable
   - default: ['--disable-features=TrackingProtection3pcd']
+  - Extra flags to pass to Chromium executable
+- `location`
+  - default: nonexistant
+  - Optional description of location of scan execution
 
 ## Inspection Result
 
@@ -113,6 +116,7 @@ Results are stored in `demo-dir` by default
     - `uri_ins`: The URL that was entered by the user.
     - `uri_dest`: The final url that was visited after any redirects.
     - `uri_redirects`: The redirect chain.
+    - `location`: If passed in as an argument, the description of the scan execution location.
 - **n.html**
   - Nth inspected page's html source.
 - **n.jpeg**

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -18,7 +18,7 @@ import { setupSessionRecordingInspector } from './inspectors/session-recording';
 import { setUpThirdPartyTrackersInspector } from './inspectors/third-party-trackers';
 import { clearDir, closeBrowser } from './helpers/utils';
 
-export type CollectorOptions = Partial<typeof DEFAULT_OPTIONS>;
+export type CollectorOptions = Partial<typeof DEFAULT_OPTIONS> & {location?: string};
 
 const DEFAULT_OPTIONS = {
     outDir: join(process.cwd(), 'bl-tmp'),
@@ -92,6 +92,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         start_time: new Date(),
         end_time: null
     };
+    if (args.location) output.location = args.location;
 
     // Log network requests and page links
     const hosts = {


### PR DESCRIPTION
This PR adds the `location` field to the collector's `output` object, if passed in with the `args`.

The Blacklight Lambda passes this parameter to the collector, this ensures that it will get stored in `inspection.json`. 