### PR TITLE
Use our puppeteer-har

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "https://github.com/the-markup/blacklight-collector#licensing",
       "dependencies": {
         "@cliqz/adblocker-puppeteer": "^1.31.1",
+        "@themarkup/puppeteer-har": "^0.0.0",
         "lodash.flatten": "^4.4.0",
         "lodash.samplesize": "^4.2.0",
         "npm": "^10.5.2",
@@ -1762,6 +1763,92 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@themarkup/puppeteer-har/-/puppeteer-har-0.0.0.tgz",
+      "integrity": "sha512-cip8YkaCMNdirimzJiKwImnrBr5tTq9uDgrzFeVHdPYLJVTBBmzte2FGDav1oWy0iaO32DwGHumMatPrkXw0mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-har": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=7.6.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.0.0"
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/chrome-har": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/chrome-har/-/chrome-har-0.13.5.tgz",
+      "integrity": "sha512-e5RVL19aa0AvlR9//hOu/t96us/iTynAJZFtryExNO+1xta1qb6b/3kZFLFPQ3UrXFG70OqhxxSCbAHKgY8JWw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "1.11.7",
+        "debug": "4.3.4",
+        "tough-cookie": "4.1.3",
+        "uuid": "9.0.0"
+      },
+      "engines": {
+        "node": ">=14.19.1"
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
+      "license": "MIT"
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@themarkup/puppeteer-har/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   "homepage": "https://github.com/the-markup/blacklight-collector#readme",
   "dependencies": {
     "@cliqz/adblocker-puppeteer": "^1.31.1",
+    "@themarkup/puppeteer-har": "^0.0.0",
     "lodash.flatten": "^4.4.0",
     "lodash.samplesize": "^4.2.0",
     "npm": "^10.5.2",
     "puppeteer": "^22.15.0",
-    "puppeteer-har": "^1.1.2",
     "run": "^1.5.0",
     "stacktrace-js": "^2.0.2",
     "tldts": "^6.1.34",


### PR DESCRIPTION
This PR uses The Markup's version of `puppeteer-har`, updated with security updates and the ability to save the `har` to a file. 