### PR TITLE
adding ga ra identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Results are stored in `demo-dir` by default
     - "canvas_font_fingerprinters"
     - "cookies"
     - "fb_pixel_events"
+    - "google_analytics_events"
     - "key_logging"
     - "session_recorders"
     - "third_party_trackers"

--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -141,3 +141,15 @@ it.skip("can parse FB Pixel tracking events - live capture", async () => {
   const report = generateReport("fb_pixel_events", rows, null, null);
   expect(report.map((r) => r.eventName)).toContain("PageView");
 });
+
+it("can parse Google Analytics tracking events", async () => {
+  const TEST_DIR = join(__dirname, "test-data", "veteransunited-1.0.3");
+  const rawEvents = loadEventData(TEST_DIR);
+  const pageUrls = [
+    'https://stats.g.doubleclick.net/j/collect?t=dc&aip=1&_r=3&v=1&_v=j82&tid=UA-30102-16&cid=852100309.1589758701&jid=2012734374&gjid=2113596298&_gid=1708403671.1589758701&_u=YGBAgEABAAAAIE~&z=549701973',
+    'https://stats.g.doubleclick.net/j/collect?t=dc&aip=1&_r=3&v=1&_v=j82&tid=UA-30102-16&cid=852100309.1589758701&jid=1563152953&gjid=595724329&_gid=1708403671.1589758701&_u=yDCAgEABAAAAIE~&z=176641512'
+  ];
+  const report = generateReport("google_analytics_events", rawEvents, null, null);
+  expect(report.length).toBe(2);
+  expect(report.map((r) => r.url).sort()).toEqual(pageUrls.sort());
+});

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -41,6 +41,7 @@ const DEFAULT_OPTIONS = {
         'canvas_font_fingerprinters',
         'cookies',
         'fb_pixel_events',
+        'google_analytics_events',
         'key_logging',
         'session_recorders',
         'third_party_trackers'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -230,11 +230,10 @@ const reportThirdPartyTrackers = (eventData: BlacklightEvent[], firstPartyDomain
 
 const reportGoogleAnalyticsEvents = (eventData: BlacklightEvent[]) => {
     return eventData.filter((event: TrackingRequestEvent) => {
-        console.log(event.url);
         return event.url.includes('stats.g.doubleclick') 
             && (
-                event.url.includes('UA-')
-                || event.url.includes('G-')
+                event.url.includes('UA-') // old version of google ids
+                || event.url.includes('G-') // this and following are new version
                 || event.url.includes('AW-')
             );
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,12 @@ export interface Global {
     __DEV_SERVER__: string;
 }
 
-export type BlacklightEvent = JsInstrumentEvent | KeyLoggingEvent | BlacklightErrorEvent | TrackingRequestEvent | SessionRecordingEvent;
+export type BlacklightEvent = 
+    JsInstrumentEvent | 
+    KeyLoggingEvent | 
+    BlacklightErrorEvent | 
+    TrackingRequestEvent | 
+    SessionRecordingEvent;
 
 export interface KeyLoggingEvent {
     type: 'KeyLogging';


### PR DESCRIPTION
This PR moves identification of the Google Analytics tracker to the Blacklight Collector. This code was previously in the lambda. 
Also expands the functionality of the identification to account for [recent changes to Google Analytics tracking](https://support.google.com/analytics/answer/11583528?hl=en#export&zippy=%2Chow-can-i-export-data-from-my-universal-analytics-property). 