### PR TITLE
Rename ga event raw -> url

### DIFF
--- a/__tests__/parser.ts
+++ b/__tests__/parser.ts
@@ -151,5 +151,5 @@ it("can parse Google Analytics tracking events", async () => {
   ];
   const report = generateReport("google_analytics_events", rawEvents, null, null);
   expect(report.length).toBe(2);
-  expect(report.map((r) => r.url).sort()).toEqual(pageUrls.sort());
+  expect(report.map((r) => r.raw).sort()).toEqual(pageUrls.sort());
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -229,13 +229,22 @@ const reportThirdPartyTrackers = (eventData: BlacklightEvent[], firstPartyDomain
 };
 
 const reportGoogleAnalyticsEvents = (eventData: BlacklightEvent[]) => {
-    return eventData.filter((event: TrackingRequestEvent) => {
+    const googleAnalyticsEvents = eventData.filter((event: TrackingRequestEvent) => {
         return event.url.includes('stats.g.doubleclick') 
             && (
                 event.url.includes('UA-') // old version of google ids
                 || event.url.includes('G-') // this and following are new version
                 || event.url.includes('AW-')
             );
+    });
+
+    return googleAnalyticsEvents.map((event: TrackingRequestEvent) => {
+        const url = event.url;
+        delete event.url;
+        return {
+            ...event,
+            raw: url,
+        };
     });
 };
 


### PR DESCRIPTION
For consistency with other events. In the future though, I think we should change all of these to 'url'.