### PR TITLE
Publish Workflow Change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: publish
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "lts/hydrogen"
+          node-version: 26
           registry-url: https://registry.npmjs.org
       - name: Update npm
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
-      - run: npm test
       - run: npm publish


### PR DESCRIPTION
After `npms` major changes to release authentication, something in the Blacklight release pipeline is broken. This is an attempt to fix the issue by relying on the `release` github action, which we so far haven't used much. 

Updates the `publish` Github action with a more recent version of node, as well as allowing it to be triggered manually. 

I've removed the testing step, since the tests can sometimes time out inconsistently and I don't want that to block publishing.